### PR TITLE
Update JSONClass to add X-FlexibleContexts

### DIFF
--- a/chapter16/src/Chapter16/JSONClass.hs
+++ b/chapter16/src/Chapter16/JSONClass.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts     #-}
 {-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 


### PR DESCRIPTION
Under GHC 7.10.x, this is needed for the import of this file into the JSONParsec.hs to avoid an error in **zipWith decode**

```
Non type-variable argument
      in the constraint: Text.Parsec.Prim.Stream s m Char
    (Use FlexibleContexts to permit this)
    When checking that ‘decode’ has the inferred type
      decode :: forall a s u (m :: * -> *).
                Text.Parsec.Prim.Stream s m Char =>
                Char -> a -> Text.Parsec.Prim.ParsecT s u m a
    In an equation for ‘pEscape’:
        pEscape
          = choice
              (zipWith
                 decode
                 "bnfrt\\\"/"
                 "\b\n\
                 \\f\r\t\\\"/")
          where
              decode c r = r <$ char c
```
